### PR TITLE
App manifest so tool can be deployed to paas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "govuk_publishing_components", "~> 21.28.1"
 gem "rails", "~> 6.0.2"
 gem "slimmer", "~> 13.2.2"
 gem "pg"
-gem "sass-rails", "~> 6.0.0"
+gem "sass-rails", "5.1.0"
 gem "uglifier", "~> 4.2"
 gem "whenever", "~> 1.0.0"
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,8 +353,12 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
+    sass-rails (5.1.0)
+      railties (>= 5.2.0)
+      sass (~> 3.1)
+      sprockets (>= 2.8, < 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
+      tilt (>= 1.1, < 3)
     sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -463,7 +467,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails (~> 4.0.0.beta4)
   rubocop-govuk
-  sass-rails (~> 6.0.0)
+  sass-rails (= 5.1.0)
   scss_lint-govuk
   sdoc
   simplecov (~> 0.18.5)

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: govuk-search-relevance-tool
+  services:
+   - relevance-db-staging
+  memory: 256M
+  buildpacks:
+  - ruby_buildpack


### PR DESCRIPTION
## Adds a manifest 
As specified in the paas documentation:
https://docs.cloud.service.gov.uk/deploying_apps.html#deploy-a-ruby-on-rails-app

[Trello]( https://trello.com/c/JwIbcWN3/1440-make-manual-judgments-tool-into-its-own-app-and-move-to-the-paas)
