### PR TITLE
Remove use of `government_navigation` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GOV.UK Search Relevance Scoring Tool
 
-A tool that can be used to collect manual relevance judgements from users as they search gov.uk.
+A tool that can be used to collect manual relevance judgements from users as they search GOV.UK.
 
 ![Search relevance screenshot](docs/assets/relevancy-tool.png)
 

--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -13,9 +13,6 @@
     <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse %>
   <% end %>
 
-  <% if content_item.government? && explore_menu_variant_b? == false %>
-    <%= render 'govuk_publishing_components/components/government_navigation', active: content_item.government_content_section %>
-  <% end %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if content_item.all_content_finder? %>


### PR DESCRIPTION
## What

Removes use of the [`government_navigation` component][gnc].

## Why

The [navigation header][nh] is being rolled out, so the use of the government navigation component isn't needed any longer.

[gnc]:https://components.publishing.service.gov.uk/component-guide/government_navigation
[nh]:https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
