### PR TITLE
Add ga4 tracking to contextual breadcrumb

### DIFF
--- a/app/views/finders/_show_header.html.erb
+++ b/app/views/finders/_show_header.html.erb
@@ -10,7 +10,7 @@
       collapse_on_mobile: true
     } %>
   <% else %>
-    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse %>
+    <%= render 'govuk_publishing_components/components/contextual_breadcrumbs', content_item: content_item.as_hash, inverse: inverse, ga4_tracking: true %>
   <% end %>
 
   <div class="govuk-grid-row">


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Enables GA4 tracking on the contextual breadcrumb by adding a `ga4_tracking: true` attribute.

## Why
Part of the GA4 migration.

## Visual changes
N/A

Trello card: https://trello.com/c/AM5JCKEd/430-add-tracking-to-super-breadcrumbs
